### PR TITLE
Allow users to favourite stocks for easier access

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,10 +1,9 @@
 """Runner module to start flask application
 
 """
-from dotenv import load_dotenv
-load_dotenv()
+# from dotenv import load_dotenv
+# load_dotenv()
 from flask_app import create_app
 
 
 app = create_app()
-app.run()

--- a/app.py
+++ b/app.py
@@ -1,10 +1,10 @@
 """Runner module to start flask application
 
 """
-# from dotenv import load_dotenv
-# load_dotenv()
+from dotenv import load_dotenv
+load_dotenv()
 from flask_app import create_app
 
 
 app = create_app()
-
+app.run()

--- a/app.py
+++ b/app.py
@@ -7,3 +7,4 @@ from flask_app import create_app
 
 
 app = create_app()
+# app.run()

--- a/flask_app/static/main.css
+++ b/flask_app/static/main.css
@@ -25,6 +25,17 @@ GENERAL
     display: none;
 }
 
+.centered {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+
+#loading-text {
+    font-size: 1.6rem;
+}
+
 /*
 HOMEPAGE
  */

--- a/flask_app/static/main.css
+++ b/flask_app/static/main.css
@@ -101,8 +101,15 @@ ANALYSIS PAGE
     font-size: 1.4rem;
 }
 
-.add-favourites {
+#add-favourites {
     display: inline;
+}
+
+#add-favourites button {
+    color: #f9d71c;
+    border: none;
+    background: none;
+    padding: 0;
 }
 
 /*

--- a/flask_app/static/main.css
+++ b/flask_app/static/main.css
@@ -90,6 +90,10 @@ ANALYSIS PAGE
     font-size: 1.4rem;
 }
 
+.add-favourites {
+    display: inline;
+}
+
 /*
 ABOUT PAGE
 */
@@ -144,7 +148,7 @@ ABOUT PAGE
 	text-decoration-thickness: 0.15rem;
 }
 
-.show {
+/* .show {
 	text-decoration: underline;
 	text-decoration-thickness: 0.15rem;
-}
+} */

--- a/flask_app/static/scripts.js
+++ b/flask_app/static/scripts.js
@@ -12,11 +12,16 @@ $(document).ready(function() {
     })
 })
 
-// Simulate a form submission on clicking of favourited stocks
-$(".favourite-stocks").click(function() {
-    symbol = this.innerHTML;
-    $("#search-form input").val(symbol);
-    $("#search-form").submit();
+// Add loading text for clicking of favourited stock
+$(".favourite-stocks").click(function (event) {
+    link = this.href;
+    event.preventDefault();
+    $("#loading-text").removeClass('hide');
+    $("#main-content").addClass('hide');
+
+    setTimeout(function () {
+        window.location.href = link;
+    }, 100)
 })
 
 $(function() {

--- a/flask_app/static/scripts.js
+++ b/flask_app/static/scripts.js
@@ -12,6 +12,12 @@ $(document).ready(function() {
     })
 })
 
+// Simulate a form submission on clicking of favourited stocks
+$(".favourite-stocks").click(function() {
+    symbol = this.innerHTML;
+    $("#search-form input").val(symbol);
+    $("#search-form").submit();
+})
 
 $(function() {
     $(".flex-item").click(function (event) {

--- a/flask_app/templates/analysis.html
+++ b/flask_app/templates/analysis.html
@@ -2,7 +2,12 @@
 
 {% block content %}
   <!-- Label for stock currently showing results for -->
-  <p class="ticker-label">Showing results for: {{ company_name }} ({{ symbol }})</p>
+  <div class="ticker-label">Showing results for: {{ company_name }} ({{ symbol }}) 
+      <form id='add-favourites' action="/add-favourites" method="POST">
+        <button type="submit" name="symbol" value={{ symbol }}><i class="far fa-star"></i></button>
+      </form>
+  </div> 
+
   <!-- Two square cards for emphasis of main results -->
   <div class="container-fluid row text-center">
     <div class="col-lg-6 d-flex justify-content-center">

--- a/flask_app/templates/analysis.html
+++ b/flask_app/templates/analysis.html
@@ -4,7 +4,15 @@
   <!-- Label for stock currently showing results for -->
   <div class="ticker-label">Showing results for: {{ company_name }} ({{ symbol }}) 
       <form id='add-favourites' action="/add-favourites" method="POST">
-        <button type="submit" name="symbol" value={{ symbol }}><i class="far fa-star"></i></button>
+        <button type="submit" name="symbol" value={{ symbol }}>
+          {% if is_favourite %}
+            <!-- Solid star icon for favourited stock -->
+            <i class="fas fa-star"></i>
+          {% else %}
+            <!-- Hollow star icon for non-favourited stock -->
+            <i class="far fa-star"></i>
+          {% endif %}
+        </button>
       </form>
   </div> 
 

--- a/flask_app/templates/base.html
+++ b/flask_app/templates/base.html
@@ -47,8 +47,8 @@
                 Favourites
               </a>
               <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
-                {% for stocks in session['favourites'] %}
-                  <li><a class="dropdown-item favourite-stocks" href="#">{{ stocks }}</a></li>
+                {% for stock in session['favourites'] %}
+                  <li><a class="dropdown-item favourite-stocks" href="{{ url_for('analysis.analysis', symbol=stock) }}">{{ stock }}</a></li>
                 {% endfor %}
               </ul>
             </li>
@@ -58,8 +58,11 @@
     </nav>
   </header>
 
+  <!-- Loading text for general use -->
+  <p class="centered hide" id="loading-text">Loading...</p>
+
   <!-- Main content section -->
-  <section>
+  <section id="main-content">
     {% block content %}{% endblock %}
   </section>
 

--- a/flask_app/templates/base.html
+++ b/flask_app/templates/base.html
@@ -14,6 +14,8 @@
   <!-- Google Fonts: Montserrat family -->
   <link rel="preconnect" href="https://fonts.gstatic.com"> 
   <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@100;500;600&display=swap" rel="stylesheet">
+  <!-- Font awesome -->
+  <script src="https://kit.fontawesome.com/b3685a7cf2.js" crossorigin="anonymous"></script>
 </head>
 <body class="dark sticky-top">
   <!-- Navigation bar -->
@@ -39,6 +41,16 @@
             </li>
             <li class="nav-item px-4">
               <a class="nav-link header-link" href="{{ url_for('index.contact') }}">Contact Us</a>
+            </li>
+            <li class="nav-item dropdown px-4">
+              <a class="nav-link header-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                Favourites
+              </a>
+              <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+                {% for stocks in session['favourites'] %}
+                  <li><a class="dropdown-item favourite-stocks" href="#">{{ stocks }}</a></li>
+                {% endfor %}
+              </ul>
             </li>
           </ul>
         </div>

--- a/flask_app/views/analysis.py
+++ b/flask_app/views/analysis.py
@@ -18,6 +18,9 @@ def analysis(symbol):
     bearish_tweets_display = []
     news_article_display = []
 
+    # Whether current symbol is favourited by user in session information
+    is_favourite = symbol in session['favourites']
+
     # Use multithreading for the API calls required
     with ThreadPoolExecutor(max_workers=5) as executor:
         get_stock_info = lambda symbol: yf.Ticker(symbol).info
@@ -59,9 +62,9 @@ def analysis(symbol):
                                         'link': article.url})
         
 
-        return render_template('analysis.html', symbol=symbol, company_name=company_name, prediction=price_movement_prediction,
-        confidence_level=confidence_level, bullish_tweets=bullish_tweets_display, bearish_tweets=bearish_tweets_display,
-        news=news_article_display)
+        return render_template('analysis.html', is_favourite=is_favourite, symbol=symbol, company_name=company_name, 
+        prediction=price_movement_prediction, confidence_level=confidence_level, bullish_tweets=bullish_tweets_display, 
+        bearish_tweets=bearish_tweets_display, news=news_article_display)
 
 
 @bp.route('/add-favourites', methods=['GET', "POST"])

--- a/flask_app/views/analysis.py
+++ b/flask_app/views/analysis.py
@@ -19,7 +19,7 @@ def analysis(symbol):
     news_article_display = []
 
     # Whether current symbol is favourited by user in session information
-    is_favourite = symbol in session['favourites']
+    is_favourite = symbol in session.get('favourites', [])
 
     # Use multithreading for the API calls required
     with ThreadPoolExecutor(max_workers=5) as executor:
@@ -70,12 +70,19 @@ def analysis(symbol):
 @bp.route('/add-favourites', methods=['GET', "POST"])
 def add_favourite():
     if request.method == 'POST':
-        # Add favourited stock to session info if it does not already exist
-        # and create a new list if session info is empty 
         symbol = request.form.to_dict()['symbol']
+        # Favourites list exist in session, add symbol to list if
+        # not already favourited, else remove it from list
         if session.get('favourites'):
-            if symbol not in session['favourites']:
-                session['favourites'] = session['favourites'] + [symbol]
+            favourites = session['favourites']
+            if symbol not in favourites:
+                favourites.append(symbol)
+            else:
+                favourites.remove(symbol)
+            
+            session['favourites'] = favourites
+
+        # Favourites list not in session, create new list with given symbol
         else:
             session['favourites'] = [symbol]
 

--- a/flask_app/views/analysis.py
+++ b/flask_app/views/analysis.py
@@ -2,7 +2,7 @@ from concurrent.futures import ThreadPoolExecutor
 from analysis.tweets_analysis import analyse_symbol
 from api.mediastack_api import get_financial_news
 from flask import (
-    Blueprint, redirect, render_template, flash
+    Blueprint, redirect, render_template, flash, request, session
 )
 import yfinance as yf
 
@@ -62,3 +62,18 @@ def analysis(symbol):
         return render_template('analysis.html', symbol=symbol, company_name=company_name, prediction=price_movement_prediction,
         confidence_level=confidence_level, bullish_tweets=bullish_tweets_display, bearish_tweets=bearish_tweets_display,
         news=news_article_display)
+
+
+@bp.route('/add-favourites', methods=['GET', "POST"])
+def add_favourite():
+    if request.method == 'POST':
+        # Add favourited stock to session info if it does not already exist
+        # and create a new list if session info is empty 
+        symbol = request.form.to_dict()['symbol']
+        if session.get('favourites'):
+            if symbol not in session['favourites']:
+                session['favourites'] = session['favourites'] + [symbol]
+        else:
+            session['favourites'] = [symbol]
+
+        return analysis(symbol)

--- a/flask_app/views/analysis.py
+++ b/flask_app/views/analysis.py
@@ -9,7 +9,7 @@ import yfinance as yf
 
 bp = Blueprint('analysis', __name__)
 
-@bp.route('/analysis')
+@bp.route('/analysis/<symbol>')
 def analysis(symbol):
     # Get up to 5 items to display for each section and pass them
     # as a list of dictionary with relevant data


### PR DESCRIPTION
Use sessions to store favourited stocks of users, so that they can click on their favourites to get to the analysis page without typing the ticker symbol.
Fixes: #10 